### PR TITLE
Add engagement metric and expanded state classification

### DIFF
--- a/routes/rl/rekomendasi.py
+++ b/routes/rl/rekomendasi.py
@@ -2,7 +2,6 @@ from flask import Blueprint, render_template
 from flask_login import login_required, current_user
 from utils.rl_utils import (
     ambil_skor_dari_db,
-    build_state,
     get_top_actions,
     get_rekomendasi_dari_action,
     simpan_log_rekomendasi,
@@ -16,12 +15,12 @@ rekomendasi_bp = Blueprint("rekomendasi", __name__, url_prefix='/rl')
 def rekomendasi():
     siswa_id = current_user.id
 
-    # Ambil skor
-    skor_vark, skor_mlsq, skor_ams = ambil_skor_dari_db(siswa_id)
+    # Ambil skor termasuk engagement
+    skor_vark, skor_mlsq, skor_ams, engagement = ambil_skor_dari_db(siswa_id)
 
     # Bangun state & top actions
     state_str, top_actions = get_top_actions(
-        skor_vark, skor_mlsq, skor_ams, limit=3)
+        skor_vark, skor_mlsq, skor_ams, engagement, limit=3)
 
     # Ambil rekomendasi dari action pertama (paling besar Q-value)
     rekom_misi, rekom_reward = get_rekomendasi_dari_action(
@@ -38,5 +37,6 @@ def rekomendasi():
         rekom_reward=rekom_reward,
         skor_vark=skor_vark,
         skor_mlsq=skor_mlsq,
-        skor_ams=skor_ams
+        skor_ams=skor_ams,
+        engagement=engagement
     )

--- a/utils/rl_utils.py
+++ b/utils/rl_utils.py
@@ -2,56 +2,102 @@ from db import mysql
 import MySQLdb.cursors
 
 
-# Ambil skor VARK, MLSQ, AMS dari tabel scores berdasarkan siswa_id
+# Hitung engagement berdasarkan frekuensi dan durasi interaksi
+def hitung_engagement(siswa_id):
+    cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
+    cursor.execute(
+        """
+        SELECT COUNT(*) AS freq, COALESCE(SUM(duration_seconds), 0) AS total_dur
+        FROM activity_log
+        WHERE user_id = %s AND start_time >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+        """,
+        (siswa_id,),
+    )
+    data = cursor.fetchone() or {"freq": 0, "total_dur": 0}
+    cursor.close()
+
+    freq = data["freq"]
+    dur = data["total_dur"]
+
+    if freq >= 10 or dur >= 3600:
+        return "m3_f3_a3"
+    if freq >= 5 or dur >= 1800:
+        return "m2_f2_a2"
+    return "m1_f1_a1"
+
+
+# Ambil skor VARK, MLSQ, AMS dan engagement dari tabel scores berdasarkan siswa_id
 def ambil_skor_dari_db(siswa_id):
     cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
 
-    cursor.execute("""
-        SELECT visual, auditory, reading, kinesthetic 
-        FROM scores_vark 
-        WHERE siswa_id = %s 
+    cursor.execute(
+        """
+        SELECT visual, auditory, reading, kinesthetic
+        FROM scores_vark
+        WHERE siswa_id = %s
         ORDER BY created_at DESC LIMIT 1
-    """, (siswa_id,))
+        """,
+        (siswa_id,),
+    )
     skor_vark = cursor.fetchone()
 
-    cursor.execute("""
-        SELECT self_regulation, task_value, control_belief, goal_orientation, self_efficacy 
-        FROM scores_mlsq 
-        WHERE siswa_id = %s 
+    cursor.execute(
+        """
+        SELECT self_regulation, task_value, control_belief, goal_orientation, self_efficacy
+        FROM scores_mlsq
+        WHERE siswa_id = %s
         ORDER BY created_at DESC LIMIT 1
-    """, (siswa_id,))
+        """,
+        (siswa_id,),
+    )
     skor_mlsq = cursor.fetchone()
 
-    cursor.execute("""
-        SELECT intrinsic, extrinsic, amotivation 
-        FROM scores_ams 
-        WHERE siswa_id = %s 
+    cursor.execute(
+        """
+        SELECT intrinsic, extrinsic, amotivation, achievement
+        FROM scores_ams
+        WHERE siswa_id = %s
         ORDER BY created_at DESC LIMIT 1
-    """, (siswa_id,))
+        """,
+        (siswa_id,),
+    )
     skor_ams = cursor.fetchone()
 
     cursor.close()
-    return skor_vark, skor_mlsq, skor_ams
+
+    engagement = hitung_engagement(siswa_id)
+    return skor_vark, skor_mlsq, skor_ams, engagement
 
 
 # Buat state string dari skor-skor
-def build_state(skor_vark, skor_mlsq, skor_ams):
-    if not (skor_vark and skor_mlsq and skor_ams):
+def build_state(skor_vark, skor_mlsq, skor_ams, engagement):
+    if not (skor_vark and skor_mlsq and skor_ams and engagement):
         return None  # Tangani jika skor belum tersedia
 
     vark = max(skor_vark, key=skor_vark.get)
-    mlsq = max(skor_mlsq, key=skor_mlsq.get)
+
+    avg_mlsq = sum(skor_mlsq.values()) / len(skor_mlsq)
+    if avg_mlsq >= 3.5:
+        mlsq = "high"
+    elif avg_mlsq >= 2.5:
+        mlsq = "medium"
+    else:
+        mlsq = "low"
+
     ams = max(skor_ams, key=skor_ams.get)
-    return f"{vark}-{mlsq}-{ams}"
+
+    return f"{vark}-{mlsq}-{ams}-{engagement}"
 
 
 # Ambil best action dari Q-table
-def get_top_actions(skor_vark, skor_mlsq, skor_ams, limit=3):
+def get_top_actions(skor_vark, skor_mlsq, skor_ams, engagement, limit=3):
     cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
-    state_str = build_state(skor_vark, skor_mlsq, skor_ams)
+    state_str = build_state(skor_vark, skor_mlsq, skor_ams, engagement)
 
     cursor.execute(
-        "SELECT * FROM q_table WHERE state = %s ORDER BY q_value DESC LIMIT %s", (state_str, limit))
+        "SELECT * FROM q_table WHERE state = %s ORDER BY q_value DESC LIMIT %s",
+        (state_str, limit),
+    )
     rows = cursor.fetchall()
     cursor.close()
 
@@ -66,19 +112,19 @@ def get_rekomendasi_dari_action(action, misi_limit=3, reward_limit=2):
         return [], []
 
     try:
-        vark, mlsq, ams = action.split("-")
+        vark, mlsq, ams, *_ = action.split("-")
     except ValueError:
         return [], []
 
     cursor.execute(
         "SELECT * FROM misi WHERE vark = %s AND mlsq = %s AND ams = %s ORDER BY RAND() LIMIT %s",
-        (vark, mlsq, ams, misi_limit)
+        (vark, mlsq, ams, misi_limit),
     )
     misi = cursor.fetchall()
 
     cursor.execute(
         "SELECT * FROM reward WHERE vark_bonus = %s AND ams_target = %s ORDER BY poin_dibutuhkan ASC LIMIT %s",
-        (vark, ams, reward_limit)
+        (vark, ams, reward_limit),
     )
     reward = cursor.fetchall()
 
@@ -95,3 +141,18 @@ def simpan_log_rekomendasi(siswa_id, state, action):
     """, (siswa_id, state, action))
     mysql.connection.commit()
     cursor.close()
+
+
+# Hasilkan daftar semua state unik
+def generate_all_states():
+    vark_opts = ["visual", "auditory", "reading", "kinesthetic"]
+    mlsq_opts = ["high", "medium", "low"]
+    ams_opts = ["intrinsic", "extrinsic", "amotivation", "achievement"]
+    eng_opts = ["m1_f1_a1", "m2_f2_a2", "m3_f3_a3"]
+    return [
+        f"{v}-{m}-{a}-{e}"
+        for v in vark_opts
+        for m in mlsq_opts
+        for a in ams_opts
+        for e in eng_opts
+    ]


### PR DESCRIPTION
## Summary
- compute weekly engagement from activity_log and classify into m1_f1_a1, m2_f2_a2, or m3_f3_a3
- expand score retrieval to include engagement and AMS achievement type; classify MLSQ levels and build richer RL state strings
- update recommendation flow and add helper to generate all 144 possible states

## Testing
- `python -m py_compile utils/rl_utils.py routes/rl/rekomendasi.py`
- `python - <<'PY'
from utils.rl_utils import generate_all_states
print(len(generate_all_states()))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6895c7226f508333b8c4798b6e6cc3b6