### PR TITLE
Add dynamic recommendations by action code

### DIFF
--- a/routes/rl/rekomendasi.py
+++ b/routes/rl/rekomendasi.py
@@ -34,19 +34,18 @@ def rekomendasi():
     for a in top_actions:
         a["action_name"] = action_map.get(a["action_code"], str(a["action_code"]))
 
-    rekom_misi, rekom_reward = get_rekomendasi_dari_action(
-        state_str, top_actions[0]["action_code"], misi_limit=5, reward_limit=5
-    )
+    best_action = top_actions[0]["action_code"] if top_actions else None
+    rekomendasi = get_rekomendasi_dari_action(best_action) if best_action else {}
 
     # Simpan log
-    simpan_log_rekomendasi(siswa_id, state_str, top_actions[0]["action_code"])
+    if best_action is not None:
+        simpan_log_rekomendasi(siswa_id, state_str, best_action)
 
     return render_template(
         "rl/rekomendasi.html",
         state=state_str,
         top_actions=top_actions,
-        rekom_misi=rekom_misi,
-        rekom_reward=rekom_reward,
+        rekomendasi=rekomendasi,
         skor_vark=skor_vark,
         skor_mlsq=skor_mlsq,
         skor_ams=skor_ams,

--- a/templates/rl/rekomendasi.html
+++ b/templates/rl/rekomendasi.html
@@ -1,9 +1,9 @@
 {% extends "base.html" %}
-{% block title %}Rekomendasi Misi & Reward{% endblock %}
+{% block title %}Rekomendasi{% endblock %}
 
 {% block content %}
 <div class="max-w-5xl mx-auto p-6 bg-white rounded-lg shadow-md space-y-8">
-    <h2 class="text-2xl font-bold text-indigo-700">🎯 Rekomendasi Misi & Reward Berdasarkan Skor Anda</h2>
+    <h2 class="text-2xl font-bold text-indigo-700">🎯 Rekomendasi Berdasarkan Skor Anda</h2>
 
     <!-- Skor State -->
     <section>
@@ -69,28 +69,61 @@
     </div>
 </section>
 
-<!-- Rekomendasi Misi dan Reward -->
+<!-- Rekomendasi dinamis berdasarkan action -->
+{% if rekomendasi.misi %}
 <section class="mt-8">
     <h3 class="text-lg font-semibold text-gray-700 mb-2">🎓 Rekomendasi Misi</h3>
     <ul class="list-disc ml-6 text-sm space-y-1">
-        {% for m in rekom_misi %}
-        <li>
-            <span class="font-semibold">{{ m.nama }}</span> — <span class="text-gray-500">{{ m.jenis }}, {{ m.durasi }} menit, {{ m.poin }} poin</span>
-        </li>
+        {% for m in rekomendasi.misi %}
+        <li><span class="font-semibold">{{ m.judul }}</span> — <span class="text-gray-500">{{ m.deskripsi }}</span> ({{ m.skor_poin }} poin)</li>
         {% endfor %}
     </ul>
 </section>
+{% endif %}
 
+{% if rekomendasi.reward %}
 <section class="mt-8">
     <h3 class="text-lg font-semibold text-gray-700 mb-2">🎁 Rekomendasi Reward</h3>
     <ul class="list-disc ml-6 text-sm space-y-1">
-        {% for r in rekom_reward %}
-        <li>
-            <span class="font-semibold">{{ r.nama_reward }}</span> — <span class="text-gray-500">{{ r.kategori }}</span> ({{ r.poin_dibutuhkan }} poin)
-        </li>
+        {% for r in rekomendasi.reward %}
+        <li><span class="font-semibold">{{ r.judul }}</span> — <span class="text-gray-500">{{ r.deskripsi }}</span> ({{ r.skor_poin }} poin)</li>
         {% endfor %}
     </ul>
 </section>
+{% endif %}
+
+{% if rekomendasi.produk %}
+<section class="mt-8">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2">🛒 Rekomendasi Pembelian</h3>
+    <ul class="list-disc ml-6 text-sm space-y-1">
+        {% for p in rekomendasi.produk %}
+        <li><span class="font-semibold">{{ p.judul }}</span> — <span class="text-gray-500">{{ p.deskripsi }}</span> ({{ p.poin }} poin)</li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}
+
+{% if rekomendasi.hukuman %}
+<section class="mt-8">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2">⚠️ Rekomendasi Hukuman</h3>
+    <ul class="list-disc ml-6 text-sm space-y-1">
+        {% for h in rekomendasi.hukuman %}
+        <li><span class="font-semibold">{{ h.judul }}</span> — <span class="text-gray-500">{{ h.deskripsi }}</span> ({{ h.skor_poin }} poin)</li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}
+
+{% if rekomendasi.pelatihan %}
+<section class="mt-8">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2">📚 Rekomendasi Konsultasi</h3>
+    <ul class="list-disc ml-6 text-sm space-y-1">
+        {% for k in rekomendasi.pelatihan %}
+        <li><span class="font-semibold">{{ k.judul }}</span> — <span class="text-gray-500">{{ k.deskripsi }}</span> ({{ k.skor_poin }} poin)</li>
+        {% endfor %}
+    </ul>
+</section>
+{% endif %}
 
     <div class="text-right pt-4">
         <a href="{{ url_for('user_dashboard.index') }}" class="text-sm text-indigo-600 hover:underline">


### PR DESCRIPTION
## Summary
- expand RL utility to fetch recommendations for reward, mission, product, punishment, or training actions
- integrate dynamic recommendation lookup in RL route
- render action-specific recommendation lists in template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895ca4a65a48333837d6e72061b9bf9