### PR TITLE
Handle empty top actions before recommendations

### DIFF
--- a/routes/rl/rekomendasi.py
+++ b/routes/rl/rekomendasi.py
@@ -4,6 +4,7 @@ from utils.rl_utils import (
     ambil_skor_dari_db,
     get_top_actions,
     get_rekomendasi_dari_action,
+    init_state_actions,
     simpan_log_rekomendasi,
     update_q_value,
 )
@@ -23,6 +24,20 @@ def rekomendasi():
     state_str, top_actions = get_top_actions(
         skor_vark, skor_mlsq, skor_ams, engagement, limit=3)
 
+    if not top_actions:
+        init_state_actions(state_str)
+        return render_template(
+            "rl/rekomendasi.html",
+            state=state_str,
+            top_actions=[],
+            rekomendasi={},
+            skor_vark=skor_vark,
+            skor_mlsq=skor_mlsq,
+            skor_ams=skor_ams,
+            engagement=engagement,
+            message="Rekomendasi belum tersedia."
+        )
+
     action_map = {
         101: "reward",
         105: "misi",
@@ -34,12 +49,11 @@ def rekomendasi():
     for a in top_actions:
         a["action_name"] = action_map.get(a["action_code"], str(a["action_code"]))
 
-    best_action = top_actions[0]["action_code"] if top_actions else None
-    rekomendasi = get_rekomendasi_dari_action(best_action) if best_action else {}
+    best_action = top_actions[0]["action_code"]
+    rekomendasi = get_rekomendasi_dari_action(best_action)
 
     # Simpan log
-    if best_action is not None:
-        simpan_log_rekomendasi(siswa_id, state_str, best_action)
+    simpan_log_rekomendasi(siswa_id, state_str, best_action)
 
     return render_template(
         "rl/rekomendasi.html",

--- a/templates/rl/rekomendasi.html
+++ b/templates/rl/rekomendasi.html
@@ -5,6 +5,10 @@
 <div class="max-w-5xl mx-auto p-6 bg-white rounded-lg shadow-md space-y-8">
     <h2 class="text-2xl font-bold text-indigo-700">🎯 Rekomendasi Berdasarkan Skor Anda</h2>
 
+    {% if message %}
+    <div class="text-gray-500 text-sm">{{ message }}</div>
+    {% endif %}
+
     <!-- Skor State -->
     <section>
         <h3 class="text-lg font-semibold text-gray-700 mb-2">🧠 State Saat Ini (Skor)</h3>

--- a/utils/rl_utils.py
+++ b/utils/rl_utils.py
@@ -2,6 +2,9 @@ from db import mysql
 import MySQLdb.cursors
 
 
+ACTION_CODES = [101, 105, 102, 103, 106]
+
+
 # Hitung engagement berdasarkan frekuensi dan durasi interaksi
 def hitung_engagement(siswa_id):
     cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
@@ -109,6 +112,22 @@ def get_top_actions(skor_vark, skor_mlsq, skor_ams, engagement, limit=3):
     cursor.close()
 
     return state_str, rows  # rows berisi action_code dan q_value
+
+
+def init_state_actions(state):
+    """Inisialisasi pasangan state-action di q_table jika belum ada."""
+    cursor = mysql.connection.cursor()
+    for code in ACTION_CODES:
+        cursor.execute(
+            """
+            INSERT INTO q_table (state, action_code, q_value)
+            VALUES (%s, %s, %s)
+            ON DUPLICATE KEY UPDATE q_value = q_value
+            """,
+            (state, code, 0.0),
+        )
+    mysql.connection.commit()
+    cursor.close()
 
 
 # Rekomendasi berdasarkan action code


### PR DESCRIPTION
## Summary
- Ensure Q-table has default state-action pairs when no actions are found
- Skip recommendation and logging if top actions list is empty and show a message
- Display user-facing message when recommendations are unavailable

## Testing
- `python -m py_compile utils/rl_utils.py routes/rl/rekomendasi.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68993773e6cc833394622ff5df31074a