### PR TITLE
feat: centralize engagement metric

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -16,6 +16,28 @@ class User(UserMixin):
     def from_siswa(self):
         return self.role == 'siswa'  # bisa dipakai di template
 
+    def get_engagement(self):
+        cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
+        cursor.execute(
+            """
+            SELECT COUNT(*) AS freq, COALESCE(SUM(duration_seconds), 0) AS total_dur
+            FROM activity_log
+            WHERE user_id = %s AND start_time >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+            """,
+            (self.id,),
+        )
+        data = cursor.fetchone() or {"freq": 0, "total_dur": 0}
+        cursor.close()
+
+        freq = data["freq"]
+        dur = data["total_dur"]
+
+        if freq >= 10 or dur >= 3600:
+            return "m3_f3_a3"
+        if freq >= 5 or dur >= 1800:
+            return "m2_f2_a2"
+        return "m1_f1_a1"
+
 # Fungsi load_user untuk Flask-Login
 
 

--- a/routes/rl/rekomendasi.py
+++ b/routes/rl/rekomendasi.py
@@ -17,8 +17,9 @@ rekomendasi_bp = Blueprint("rekomendasi", __name__, url_prefix='/rl')
 def rekomendasi():
     siswa_id = current_user.id
 
-    # Ambil skor termasuk engagement
-    skor_vark, skor_mlsq, skor_ams, engagement = ambil_skor_dari_db(siswa_id)
+    # Ambil skor dan hitung engagement melalui model User
+    skor_vark, skor_mlsq, skor_ams = ambil_skor_dari_db(siswa_id)
+    engagement = current_user.get_engagement()
 
     # Bangun state & top actions
     state_str, top_actions = get_top_actions(

--- a/utils/rl_utils.py
+++ b/utils/rl_utils.py
@@ -5,31 +5,7 @@ import MySQLdb.cursors
 ACTION_CODES = [101, 105, 102, 103, 106]
 
 
-# Hitung engagement berdasarkan frekuensi dan durasi interaksi
-def hitung_engagement(siswa_id):
-    cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
-    cursor.execute(
-        """
-        SELECT COUNT(*) AS freq, COALESCE(SUM(duration_seconds), 0) AS total_dur
-        FROM activity_log
-        WHERE user_id = %s AND start_time >= DATE_SUB(NOW(), INTERVAL 7 DAY)
-        """,
-        (siswa_id,),
-    )
-    data = cursor.fetchone() or {"freq": 0, "total_dur": 0}
-    cursor.close()
-
-    freq = data["freq"]
-    dur = data["total_dur"]
-
-    if freq >= 10 or dur >= 3600:
-        return "m3_f3_a3"
-    if freq >= 5 or dur >= 1800:
-        return "m2_f2_a2"
-    return "m1_f1_a1"
-
-
-# Ambil skor VARK, MLSQ, AMS dan engagement dari tabel scores berdasarkan siswa_id
+# Ambil skor VARK, MLSQ, dan AMS dari tabel scores berdasarkan siswa_id
 def ambil_skor_dari_db(siswa_id):
     cursor = mysql.connection.cursor(MySQLdb.cursors.DictCursor)
 
@@ -68,8 +44,7 @@ def ambil_skor_dari_db(siswa_id):
 
     cursor.close()
 
-    engagement = hitung_engagement(siswa_id)
-    return skor_vark, skor_mlsq, skor_ams, engagement
+    return skor_vark, skor_mlsq, skor_ams
 
 
 # Buat state string dari skor-skor


### PR DESCRIPTION
## Summary
- add `User.get_engagement` to query activity_log and compute engagement level
- use `current_user.get_engagement` in recommendation flow
- simplify `rl_utils.ambil_skor_dari_db` to return only score sets

## Testing
- `python -m py_compile models/user.py utils/rl_utils.py routes/rl/rekomendasi.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689938af5ed88333b8c7e072158a58ff